### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/builder/Dockerfile* github-language=docker


### PR DESCRIPTION
Fix syntax highlighting for `/builder/Dockerfile.nonheadless`